### PR TITLE
Add support loading shader from raw bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "filum"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "filum"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Keitaro Oguri <ogukei256@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/ogukei/filum"
-keywords = ["gpgpu", "vulkan", "pallarel"]
+keywords = ["gpgpu", "vulkan"]
 license-file = "LICENSE"
 readme = "README.md"
 description = "Easy GPGPU powered by Vulkan"

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,9 @@ pub enum ErrorCode {
     VkResult(VkResult),
     FFI(std::ffi::NulError),
     SuitablePhysicalDeviceNotFound,
-    SuitableBufferMemoryTypeNotFound
+    SuitableBufferMemoryTypeNotFound,
+    ShaderLoadIO(std::io::Error),
+    ShaderLoadUnaligned,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
We can now load compute shader from raw bytes.

```rust
let pipeline = PipelineBuilder::new(buffer)
    .shader_bytes(some_u8_vec)
    .build()
    .unwrap();
```